### PR TITLE
add au address-keys

### DIFF
--- a/geocontext.json
+++ b/geocontext.json
@@ -3,7 +3,15 @@
         "left-hand-traffic": true
     },
     "au": {
-        "left-hand-traffic": true
+        "left-hand-traffic": true,
+        "address-keys": [
+            "addr:unit",
+            "addr:housenumber",
+            "addr:street",
+            "addr:suburb",
+            "addr:state",
+            "addr:postcode"
+        ]
     },
     "at": {
         "speed-limits": [


### PR DESCRIPTION
Australia makes use of `addr:unit`, `addr:housenumber` and `addr:street`.

Use of `addr:suburb`, `addr:state`, `addr:postcode` are disputed within the community given these can be derived from the existing boundaries data we have, however they are still sometimes used. We distinctly don't make use of `addr:city` and consider these as errors.