### PR TITLE
Update entry for Japan (jp)

### DIFF
--- a/geocontext.json
+++ b/geocontext.json
@@ -256,7 +256,36 @@
         "left-hand-traffic": true
     },
     "jp": {
-        "left-hand-traffic": true
+        "left-hand-traffic": true,
+        "speed-limits": [
+            20,
+            30,
+            40,
+            50,
+            60,
+            70,
+            80,
+            90,
+            100,
+            110,
+            120
+        ],
+        "languages": [
+            "ja",
+            "ja-Hira",
+            "ja-Latn",
+            "en"
+        ],
+        "address-keys": [
+            "addr:province",
+            "addr:county",
+            "addr:city",
+            "addr:suburb",
+            "addr:quarter",
+            "addr:neighbourhood",
+            "addr:block_number",
+            "addr:housenumber"
+        ]
     },
     "ke": {
         "left-hand-traffic": true


### PR DESCRIPTION
- Speed limits for public highways are 20-120 km/h
- The primary languages is Japanese and many POIs have transliterated names in Hiragana and Latin alphabets.
- POI names tend to be first translated into English.
- For addressing: <https://wiki.openstreetmap.org/wiki/JA:Key:addr:*#%E6%97%A5%E6%9C%AC%E3%81%AE%E4%BD%8F%E6%89%80%E8%A1%A8%E8%A8%98%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6>